### PR TITLE
feat: v0.6.0 OpenAI provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,82 @@
+# Changelog
+
+All notable changes to llm-monitor are documented in this file.
+
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.5.0] - 2026-04-09
+
+### Added
+
+- **xAI Grok provider** (`providers/grok.py`) — spend monitoring via the xAI Management API
+- Invoice preview endpoint for month-to-date spend with per-model cost breakdown
+- Spending limits endpoint with utilisation percentage and threshold detection
+- Prepaid balance endpoint
+- Usage analytics endpoint for per-model time-series token and spend data
+- Dual credential support: management key (primary, 4-tier resolution) and optional API key
+- Team ID resolution from config (`providers.grok.team_id`) or `$XAI_TEAM_ID` env var
+- Redaction pattern for `xai-*` keys in security module
+- Config section for Grok provider
+- Test fixtures for all four Management API responses
+
+### Fixed
+
+- Table and monitor formatters now render USD-based usage windows as dollar values instead of percentages
+
+## [0.4.0] - 2026-04-08
+
+### Added
+
+- **Monitor TUI** (`--monitor` flag) — Rich Live dashboard with auto-refreshing provider status
+- Per-provider status panels with usage bars, model breakdowns, and sparklines
+- Compact mode for smaller terminals
+- Configurable refresh interval
+- Colour-coded threshold indicators (normal/warning/critical)
+
+## [0.3.0] - 2026-04-07
+
+### Added
+
+- **Background daemon** (`llm-monitor daemon start/stop/status/install`) — polls providers on a schedule and writes to the shared SQLite history database
+- PID file management with stale PID detection
+- `daemon install` generates a systemd user unit for automatic startup
+- CLI reads from daemon's database when available, falls back to direct fetching
+- **Docker deployment** — `Dockerfile` and `docker-compose.yml` for containerised daemon operation
+- Container mode detection (skips permission checks, uses env var paths)
+- Per-provider poll interval override in config
+- Daemon-aware provider base class with backoff state persistence
+
+## [0.2.0] - 2026-04-07
+
+### Added
+
+- **SQLite history store** (`history.py`) — records provider snapshots with WAL mode and retention pruning
+- `llm-monitor history` — query historical usage data with time range filters
+- `llm-monitor report` — generate usage summaries (daily/weekly/monthly) with trend analysis
+- `llm-monitor export` — export history to CSV or JSON
+- Meaningful-change detection to avoid storing duplicate snapshots
+- Per-model usage tracking in dedicated `model_usage` table
+
+## [0.1.0] - 2026-04-06
+
+### Added
+
+- **Anthropic Claude provider** — subscription utilisation tracking via Claude Code OAuth credentials
+- Read-only consumer of `~/.claude/.credentials.json` (never writes to the file)
+- Five usage windows: Session (5h), Daily, Weekly, Monthly, and Opus-specific
+- Per-model usage breakdown (Opus, Sonnet, Haiku token counts)
+- **CLI with three output modes**: JSON (default, no flag), `--now` (Rich table), `--monitor` (TUI, added in v0.4.0)
+- **Provider architecture** — abstract `Provider` base class with `@register_provider` decorator
+- 4-tier credential resolution: `key_command` > env var > keyring > provider-specific file
+- `SecretStr` wrapper with safe `__repr__` — secrets never leak in logs or output
+- **JSON cache** with `poll_interval`-based TTL and `fcntl.flock()` file locking
+- **TOML configuration** from `~/.config/llm-monitor/config.toml` with env var path overrides
+- **Security module** — credential sanitisation, secure file I/O (`0o600`/`0o700`), atomic writes
+- Allowed-hosts enforcement for credential-bearing HTTP requests
+- `key_command` execution with `shell=False` and 10s timeout
+- Rich table formatter with TTY-adaptive column widths and colour-coded thresholds
+- JSON formatter with stable schema (stdout-only, stderr for messaging)
+- Exit codes: 0 (ok), 1 (config error), 2 (all auth fail), 3 (partial), 4 (all network fail)
+- CI pipeline via GitHub Actions (lint, test, type check)
+- Full test suite: providers, formatters, cache, config, security, CLI, models

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Monitor your LLM consumption from local and online services.
 
-Currently supports **Anthropic Claude** (subscription utilisation tracking). Future versions will add Grok (xAI), OpenAI, Ollama, and local system metrics.
+Currently supports **Anthropic Claude** (subscription utilisation tracking) and **OpenAI** (API spend and per-model usage via Admin API). Future versions will add Grok (xAI), Ollama, and local system metrics.
 
 ## Quick Start
 
@@ -104,11 +104,24 @@ uv build
 
 ## Prerequisites
 
+### Claude
+
 The Claude provider reads OAuth credentials managed by Claude Code:
 
 1. Install [Claude Code](https://claude.ai/code)
 2. Run `claude /login` to authenticate
 3. The tool reads `~/.claude/.credentials.json` (read-only, never writes to it)
+
+### OpenAI
+
+The OpenAI provider uses the Administration API, which requires an **Admin API Key** (`sk-admin-*`):
+
+1. Go to [platform.openai.com](https://platform.openai.com) → Settings → Organisation → Admin Keys
+2. Create an admin key (only Organisation Owners can do this)
+3. Set the environment variable: `export OPENAI_ADMIN_KEY="sk-admin-..."`
+4. Enable in config: set `[providers.openai] enabled = true`
+
+Standard project keys (`sk-proj-*`) do **not** have access to the Usage or Costs APIs.
 
 ## Configuration
 
@@ -130,6 +143,11 @@ enabled = true
 credentials_path = ""            # empty = default (~/.claude/.credentials.json)
 show_opus = true
 
+[providers.openai]
+enabled = false
+admin_key_env = "OPENAI_ADMIN_KEY"       # Admin key (sk-admin-*), NOT project key
+# admin_key_command = "pass show llm-monitor/openai-admin"
+
 [history]
 enabled = true
 retention_days = 90
@@ -147,8 +165,8 @@ Override paths via environment variables:
 
 Credentials are **never stored in the config file**. Resolution order:
 
-1. **`key_command`** — execute a shell command (e.g., `pass show llm-monitor/openai`)
-2. **Environment variable** — e.g., `$OPENAI_API_KEY`, `$XAI_API_KEY`
+1. **`key_command`** — execute a shell command (e.g., `pass show llm-monitor/openai-admin`)
+2. **Environment variable** — e.g., `$OPENAI_ADMIN_KEY`, `$XAI_API_KEY`
 3. **System keyring** — GNOME Keyring, KDE Wallet, KeePassXC via Python `keyring`
 4. **Provider credential file** — Claude only (`~/.claude/.credentials.json`)
 
@@ -365,7 +383,7 @@ services:
       - ${HOME}/.config/llm-monitor/config.toml:/home/monitor/.config/llm-monitor/config.toml:ro
       - ${HOME}/.claude/.credentials.json:/home/monitor/.claude/.credentials.json:ro
     environment:
-      - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - OPENAI_ADMIN_KEY=${OPENAI_ADMIN_KEY}
       - XAI_API_KEY=${XAI_API_KEY}
 
 volumes:

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -446,36 +446,111 @@ The backoff state is persisted in the provider's cache file so it survives proce
 
 ---
 
-### 3.3 OpenAI - v0.4.0
+### 3.3 OpenAI - v0.6.0
 
-**Type:** API spend and credit monitoring
+**Type:** API spend and usage monitoring
 
-**Data source:** OpenAI platform API endpoints
+**Data source:** OpenAI Administration API endpoints (Usage API and Costs API)
 
 **Authentication:**
-- API key from OpenAI Console, resolved via `resolve_credential()` (keyring, env var, or key_command).
-- Default env var: `$OPENAI_API_KEY`.
+- **Admin API key** (`sk-admin-*` prefix) from OpenAI Console → Settings → Organization → Admin Keys.
+- Only Organisation Owners can create admin keys. Required scope: `api.usage.read`.
+- Resolved via `resolve_credential()` with credential name `admin_key` (keyring, env var, or key_command).
+- Default env var: `$OPENAI_ADMIN_KEY`.
+- Standard project keys (`sk-proj-*`) do **not** have access to Usage or Costs endpoints.
 
 **Available endpoints:**
 
-| Endpoint | Data | Notes |
-|----------|------|-------|
-| `GET /v1/organization/usage/completions` | Token usage by model, project, time bucket | Official Usage API |
-| `GET /v1/organization/costs` | Cost breakdown by line item | Official Costs API |
-| `GET /v1/dashboard/billing/subscription` | Plan and billing cycle details | Undocumented but widely used |
-| `GET /v1/dashboard/billing/credit_grants` | Remaining credit balance | Undocumented but widely used |
+| Endpoint | Data | Auth | Notes |
+|----------|------|------|-------|
+| `GET /v1/organization/usage/completions` | Token usage by model, project, time bucket | Admin key | Official Usage API. `group_by` supports: `project_id`, `user_id`, `api_key_id`, `model`, `batch`, `service_tier`. |
+| `GET /v1/organization/costs` | Cost breakdown by line item, project | Admin key | Official Costs API. `group_by` supports: `project_id`, `line_item`. |
 
-**Mapped usage windows (planned):**
+**Removed endpoints (no longer viable):**
+- ~~`/v1/dashboard/billing/subscription`~~ — undocumented, now requires browser session key (not API key). Dead as of late 2025.
+- ~~`/v1/dashboard/billing/credit_grants`~~ — same. No programmatic credit balance API exists.
+
+**Usage API query parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `start_time` | integer | Yes | Unix timestamp (seconds), inclusive |
+| `end_time` | integer | No | Unix timestamp (seconds), exclusive. Defaults to now. |
+| `bucket_width` | string | No | `1m`, `1h`, or `1d` (default `1d`) |
+| `group_by` | array | No | See per-endpoint list above |
+| `project_ids` | array | No | Filter by project |
+| `models` | array | No | Filter by model |
+| `api_key_ids` | array | No | Filter by API key |
+| `user_ids` | array | No | Filter by user |
+
+**Usage API response schema:**
+```json
+{
+  "object": "page",
+  "data": [
+    {
+      "object": "bucket",
+      "start_time": 1736616660,
+      "end_time": 1736640000,
+      "results": [
+        {
+          "object": "organization.usage.completions.result",
+          "input_tokens": 141201,
+          "output_tokens": 9756,
+          "input_cached_tokens": 0,
+          "input_audio_tokens": 0,
+          "output_audio_tokens": 0,
+          "num_model_requests": 470,
+          "model": "gpt-4o-2024-08-06"
+        }
+      ]
+    }
+  ],
+  "has_more": false,
+  "next_page": null
+}
+```
+
+**Costs API response schema:**
+```json
+{
+  "object": "page",
+  "data": [
+    {
+      "object": "bucket",
+      "start_time": 1736553600,
+      "end_time": 1736640000,
+      "results": [
+        {
+          "object": "organization.costs.result",
+          "amount": {
+            "value": 0.13,
+            "currency": "usd"
+          },
+          "line_item": "gpt-4o-2024-08-06",
+          "project_id": null
+        }
+      ]
+    }
+  ],
+  "has_more": false,
+  "next_page": null
+}
+```
+
+**Mapped usage windows:**
 
 | Window | Source | Unit | Notes |
 |--------|--------|------|-------|
-| Credit Balance | `/v1/dashboard/billing/credit_grants` | usd | Remaining prepaid credits |
-| Spend (MTD) | `/v1/organization/costs` | usd | Month-to-date API spend |
-| Rate Limit | Response headers | percent | Per-model RPM/TPM |
+| Spend (MTD) | `/v1/organization/costs` | usd | Month-to-date API spend, summed across all buckets |
 
-**Extras dict:** `{ "plan": "...", "models_used": [...], "top_model_spend": {...} }`
+**Extras dict:** `{ "models_used": [...], "top_model_spend": {...}, "bucket_width": "1d" }`
 
-**Per-model breakdown:** The OpenAI Usage API natively supports grouping by model via the `group_by[]=model` parameter. The provider populates `model_usage` with per-model token counts and costs. This is the richest per-model data of any provider.
+**Per-model breakdown:** The Usage API natively supports `group_by=model`. The provider calls both endpoints with model grouping:
+- `/v1/organization/usage/completions?group_by=model` → per-model token counts (`input_tokens`, `output_tokens`, `input_cached_tokens`, `num_model_requests`)
+- `/v1/organization/costs?group_by=line_item` → per-model cost in USD
+
+These are merged into `ModelUsage` entries with both token counts and costs. This is the richest per-model data of any provider.
 
 **Allowed hosts:** `api.openai.com` (HTTPS only).
 
@@ -1022,9 +1097,9 @@ management_key_env = "XAI_MANAGEMENT_KEY"
 # ─── Provider: OpenAI ─────────────────────────────────────────
 [providers.openai]
 enabled = false
-key_env = "OPENAI_API_KEY"
-# key_command = "pass show llm-monitor/openai"
-# key_keyring = true
+admin_key_env = "OPENAI_ADMIN_KEY"       # Admin key (sk-admin-*), NOT project key
+# admin_key_command = "pass show llm-monitor/openai-admin"
+# admin_key_keyring = true
 
 # ─── Provider: Ollama ─────────────────────────────────────────
 [providers.ollama]
@@ -1415,10 +1490,10 @@ Use the Python `keyring` library, which interfaces with the D-Bus Secret Service
 ```bash
 # User stores a key (one-time setup)
 llm-monitor config set-key --provider openai
-# Prompts securely for the key, stores via keyring
+# Prompts securely for the admin key, stores via keyring
 
 # Or via secret-tool directly
-secret-tool store --label="llm-monitor: OpenAI API Key" \
+secret-tool store --label="llm-monitor: OpenAI Admin Key" \
     application llm-monitor provider openai
 ```
 
@@ -1428,9 +1503,9 @@ The config file may contain a `key_command` directive that executes a shell comm
 
 ```toml
 [providers.openai]
-key_command = "pass show llm-monitor/openai"
-# or: key_command = "secret-tool lookup application llm-monitor provider openai"
-# or: key_command = "vault kv get -field=api_key secret/llm-monitor/openai"
+admin_key_command = "pass show llm-monitor/openai-admin"
+# or: admin_key_command = "secret-tool lookup application llm-monitor provider openai"
+# or: admin_key_command = "vault kv get -field=admin_key secret/llm-monitor/openai"
 ```
 
 **Tier 3: Environment variables**
@@ -1438,7 +1513,7 @@ key_command = "pass show llm-monitor/openai"
 Standard practice for CI/CD and containerised environments. Acknowledged risk: readable via `/proc/$PID/environ` by the same user. Acceptable for ephemeral contexts.
 
 ```bash
-export OPENAI_API_KEY="sk-..."
+export OPENAI_ADMIN_KEY="sk-admin-..."
 export XAI_API_KEY="xai-..."
 export XAI_MANAGEMENT_KEY="xai-mgmt-..."
 export XAI_TEAM_ID="..."
@@ -1450,7 +1525,7 @@ Read-only access to `~/.claude/.credentials.json`. This file is owned and manage
 
 **Resolution order per provider:**
 1. `key_command` (if configured, execute and read stdout)
-2. `key_env` / well-known env var (e.g., `$OPENAI_API_KEY`)
+2. `key_env` / well-known env var (e.g., `$OPENAI_ADMIN_KEY`)
 3. System keyring lookup (`keyring.get_password(...)`)
 4. Provider-specific credential file (Claude only)
 
@@ -1879,7 +1954,7 @@ The JSON output schema (Section 4.2.3) and config file format (Section 4.6) are 
 | OQ-009 | **GTK4 vs GTK3 for v2?** GTK4 + libadwaita is modern GNOME, but AppIndicator3 is GTK3. May need bridging or alternative tray approach. | Medium (v2) | GTK | Open |
 | ~~OQ-010~~ | ~~**Licensing?** MIT vs GPL. MIT is simpler; GPL aligns with GNOME ecosystem.~~ | ~~Low~~ | ~~All~~ | **Closed:** MIT license committed to repo. `pyproject.toml` updated accordingly. |
 | ~~OQ-011~~ | ~~**Does xAI have a programmatic billing/usage API?** Console shows spend, but no documented REST endpoint for querying balance or MTD cost found. Rate limit headers provide per-request data only.~~ | ~~High~~ | ~~Grok~~ | **Closed:** Yes. The xAI Management API (`management-api.x.ai`) provides full billing, spend, usage analytics, prepaid balance, and spending limit endpoints. Requires a separate Management Key (not the inference API key) and team ID. See updated Section 3.2. |
-| OQ-012 | **OpenAI billing endpoint stability?** `/v1/dashboard/billing/subscription` and `/v1/dashboard/billing/credit_grants` are undocumented but widely used. The official Usage API (`/v1/organization/usage/...`) requires admin-level access. | Medium | OpenAI | Open |
+| ~~OQ-012~~ | ~~**OpenAI billing endpoint stability?** `/v1/dashboard/billing/subscription` and `/v1/dashboard/billing/credit_grants` are undocumented but widely used. The official Usage API (`/v1/organization/usage/...`) requires admin-level access.~~ | ~~Medium~~ | ~~OpenAI~~ | **Closed:** Confirmed. The undocumented `/v1/dashboard/billing/*` endpoints are dead — they require browser session keys as of late 2025. The official Usage API and Costs API (`/v1/organization/usage/*`, `/v1/organization/costs`) require an Admin API Key (`sk-admin-*`), not a standard project key. No programmatic credit balance API exists. See updated Section 3.3. |
 | OQ-013 | **Ollama metrics endpoint availability?** Ollama does not have a built-in `/metrics` Prometheus endpoint in all versions. The proxy approach (ollama-metrics) is an alternative but adds a dependency. Should we support both paths? | Medium | Ollama | Open |
 | OQ-014 | **AMD GPU support depth?** `pyamdgpuinfo` is limited. `rocm-smi` subprocess parsing is more complete but slower. What level of AMD support is needed? | Low | Local | Open |
 | ~~OQ-015~~ | ~~**Provider plugin system: entry_points vs explicit registration?** Entry points allow third-party providers but add packaging complexity. Explicit registration in a registry dict is simpler for v1.~~ | ~~Low~~ | ~~Architecture~~ | **Closed:** Explicit registration via `@register_provider` decorator and module-level dict for v1. See Section 2.2. |
@@ -1906,7 +1981,7 @@ The JSON output schema (Section 4.2.3) and config file format (Section 4.6) are 
 | A-003 | The Claude response schema (`five_hour`, `seven_day`, `seven_day_opus`) is reasonably stable across plan types. | Schema changes require parser updates. Defensive parsing mitigates. | Claude |
 | A-004 | The `anthropic-beta: oauth-2025-04-20` header value will remain valid or a successor discoverable. | API calls fail. Monitor Claude Code releases for changes. | Claude |
 | A-005 | Python 3.10+ is available on target Linux distributions (Ubuntu 22.04+, Fedora 36+, Arch current). | Older distros need `pyenv` or container. | All |
-| A-006 | OpenAI's `/v1/organization/usage/completions` endpoint is accessible with a standard API key (not just admin keys). | If admin-only, fall back to undocumented billing endpoints. | OpenAI |
+| ~~A-006~~ | ~~OpenAI's `/v1/organization/usage/completions` endpoint is accessible with a standard API key (not just admin keys).~~ | ~~If admin-only, fall back to undocumented billing endpoints.~~ | ~~OpenAI~~ | *Falsified. Both Usage and Costs APIs require an Admin API Key (`sk-admin-*`) with `api.usage.read` scope. The undocumented billing endpoints are also dead. Provider now requires admin key. See OQ-012 closure and updated Section 3.3.* |
 | A-007 | Ollama runs on `localhost:11434` by default and the `/api/ps` and `/api/tags` endpoints are stable. | Ollama API changes would require updates. These endpoints have been stable for 2+ years. | Ollama |
 | A-008 | NVIDIA GPU monitoring via `pynvml` works on Linux with standard NVIDIA drivers installed. | If driver mismatch, GPU metrics fail gracefully. | Local |
 | ~~A-009~~ | ~~Rate limiting on Claude's usage endpoint is per-token, not per-IP. Running alongside Claude Code's own polling won't cause mutual 429s.~~ | ~~If per-IP, concurrent polling could cause interference.~~ | ~~Claude~~ | *Superseded by D-004 (10m poll interval) and D-041 (exponential backoff). Design is now robust regardless of rate-limit scope.* |
@@ -1975,6 +2050,7 @@ The JSON output schema (Section 4.2.3) and config file format (Section 4.6) are 
 | D-049 | **`--interval`/`-i` flag: integer seconds, default 30, minimum 5.** | Only meaningful with `--monitor` — controls UI refresh rate. Minimum 5 seconds prevents accidental API hammering in standalone mode. Values < 5 clamped to 5 with a stderr warning. | 2026-04-08 | Accepted |
 | D-050 | **Provider health indicator thresholds based on poll_interval multiples.** | Green `●` = data age ≤ 1× poll_interval (healthy). Yellow `●` = data age > 1× but ≤ 3× poll_interval (stale — daemon may have missed a cycle). Red `●` = data age > 3× poll_interval OR provider has errors. poll_interval read from config (default 600s, per-provider override respected). | 2026-04-08 | Accepted |
 | D-051 | **`--notify` deferred to v0.9.0. No flag added in v0.4.0.** | The spec's roadmap places notifications at v0.9.0. Adding a dead flag creates confusion. Desktop notification support arrives with the notification engine. | 2026-04-08 | Accepted |
+| D-052 | **OpenAI provider requires Admin API Key (`sk-admin-*`), not a standard project key.** | The Usage API and Costs API both require the `api.usage.read` scope, which is only available on admin keys. Standard project keys (`sk-proj-*`) return 403. The undocumented `/v1/dashboard/billing/*` endpoints are dead (require browser session keys since late 2025). No credit balance API exists. Env var: `$OPENAI_ADMIN_KEY`. Only Organisation Owners can create admin keys. See OQ-012. | 2026-04-10 | Accepted |
 
 ---
 
@@ -2223,17 +2299,30 @@ The JSON output schema (Section 4.2.3) and config file format (Section 4.6) are 
 
 ### v0.6.0 - OpenAI Provider
 
-- [ ] OpenAI provider implementation
-- [ ] Usage API integration (`/v1/organization/usage/completions`)
-- [ ] Per-model usage breakdown via `group_by[]=model` populating `model_usage` table
-- [ ] Billing endpoint integration (credit balance, subscription)
-- [ ] Config section for OpenAI
+- [ ] OpenAI provider implementation (`providers/openai.py`)
+- [ ] Usage API integration: `GET /v1/organization/usage/completions` with `group_by=model` for per-model token counts
+- [ ] Costs API integration: `GET /v1/organization/costs` for MTD spend, `group_by=line_item` for per-model costs
+- [ ] Merged per-model breakdown: usage tokens + costs joined into `ModelUsage` entries
+- [ ] Admin key credential resolution via `$OPENAI_ADMIN_KEY` (not standard project key)
+- [ ] Config section for OpenAI (`providers.openai` with `admin_key_env`)
+- [ ] Provider registration in `providers/__init__.py`
+- [ ] Redaction pattern verification (`sk-[a-zA-Z0-9-]{20,}` already covers `sk-admin-*`)
 
 **Tests:**
-- [ ] `test_providers/test_openai.py` — usage response parsing with per-model breakdown, cost endpoint parsing, credit balance mapping, credential resolution via `$OPENAI_API_KEY`, 429/5xx handling, undocumented endpoint fallback, mocked HTTP via `respx`
+- [ ] Usage API response parsing into per-model `ModelUsage` entries (input/output/cached tokens, request counts)
+- [ ] Costs API response parsing into "Spend (MTD)" `UsageWindow` (USD)
+- [ ] Per-model cost parsing via `group_by=line_item`
+- [ ] Token + cost merge: models from both endpoints combined into unified `ModelUsage`
+- [ ] Admin key credential resolution via `$OPENAI_ADMIN_KEY`
+- [ ] `is_configured()` validation (requires admin key)
+- [ ] 401/403 error handling (wrong key type or missing `api.usage.read` scope)
+- [ ] 429 rate limit backoff handling
+- [ ] Network error handling
+- [ ] Multi-bucket response aggregation (summing across time buckets)
+- [ ] Mocked HTTP via `respx` for all endpoints
 
 **Documentation:**
-- [ ] README.md update — add OpenAI to supported providers list, OpenAI credential setup (`$OPENAI_API_KEY`), OpenAI-specific config example, per-model cost breakdown explanation, credit balance monitoring
+- [ ] README.md update — add OpenAI to supported providers list, admin key setup (`$OPENAI_ADMIN_KEY`, organisation owner requirement), OpenAI-specific config example, per-model cost and usage breakdown explanation
 
 ### v0.7.0 - Ollama Provider
 
@@ -2362,7 +2451,7 @@ services:
       - ${HOME}/.claude/.credentials.json:/home/monitor/.claude/.credentials.json:ro
     environment:
       # Cloud provider API keys (alternative to keyring)
-      - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - OPENAI_ADMIN_KEY=${OPENAI_ADMIN_KEY}
       - XAI_API_KEY=${XAI_API_KEY}
       - XAI_MANAGEMENT_KEY=${XAI_MANAGEMENT_KEY}
       - XAI_TEAM_ID=${XAI_TEAM_ID}

--- a/src/llm_monitor/config.py
+++ b/src/llm_monitor/config.py
@@ -34,6 +34,10 @@ DEFAULT_CONFIG: dict = {
             "credentials_path": "",
             "show_opus": True,
         },
+        "openai": {
+            "enabled": False,
+            "admin_key_env": "OPENAI_ADMIN_KEY",
+        },
     },
     "history": {
         "enabled": True,

--- a/src/llm_monitor/providers/__init__.py
+++ b/src/llm_monitor/providers/__init__.py
@@ -39,3 +39,4 @@ def get_enabled_providers(config: dict) -> list[type[Provider]]:
 
 # Import concrete providers to trigger registration
 from llm_monitor.providers.claude import ClaudeProvider  # noqa: E402, F401
+from llm_monitor.providers.openai import OpenAIProvider  # noqa: E402, F401

--- a/src/llm_monitor/providers/openai.py
+++ b/src/llm_monitor/providers/openai.py
@@ -1,0 +1,402 @@
+"""OpenAI usage provider.
+
+Uses the OpenAI Administration API (Usage API and Costs API) for
+organisation-level usage and spend monitoring.  Requires an Admin API
+Key (sk-admin-*) with the ``api.usage.read`` scope.
+
+See SPEC.md Section 3.3 for endpoint mapping and design rationale.
+See D-052 for the admin key requirement decision.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+from typing import Optional
+
+import httpx
+
+from llm_monitor.models import (
+    CredentialError,
+    ModelUsage,
+    ProviderStatus,
+    SecretStr,
+    UsageWindow,
+    compute_status,
+)
+from llm_monitor.providers import register_provider
+from llm_monitor.providers.base import Provider
+from llm_monitor.security import is_container_mode, run_key_command
+
+API_BASE = "https://api.openai.com/v1"
+
+
+@register_provider
+class OpenAIProvider(Provider):
+    """Fetches usage and cost data from the OpenAI Administration API."""
+
+    def __init__(self, config: dict) -> None:
+        self._config = config
+
+    def name(self) -> str:
+        return "openai"
+
+    def display_name(self) -> str:
+        return "OpenAI"
+
+    def is_configured(self) -> bool:
+        """Requires an admin API key."""
+        try:
+            return self._resolve_admin_key() is not None
+        except CredentialError:
+            return False
+
+    def _resolve_admin_key(self) -> SecretStr | None:
+        """Resolve the admin key through the credential chain.
+
+        Resolution order mirrors ``Provider.resolve_credential()`` but
+        reads ``admin_key_command`` / ``admin_key_env`` config keys.
+        """
+        provider_cfg = self._config.get("providers", {}).get("openai", {})
+
+        # Tier 1: admin_key_command (hard fail on error)
+        key_cmd = provider_cfg.get("admin_key_command")
+        if key_cmd:
+            return run_key_command(key_cmd)
+
+        # Tier 2: environment variable
+        env_var = provider_cfg.get("admin_key_env") or "OPENAI_ADMIN_KEY"
+        value = os.environ.get(env_var)
+        if value:
+            return SecretStr(value)
+
+        # Tier 3: keyring (skip in container mode)
+        if not is_container_mode():
+            try:
+                import keyring as kr
+
+                secret = kr.get_password("llm-monitor/openai", "admin_key")
+                if secret:
+                    return SecretStr(secret)
+            except Exception:
+                pass
+
+        # Tier 4: nothing found
+        return None
+
+    async def fetch_usage(self, client: httpx.AsyncClient) -> ProviderStatus:
+        """Fetch usage and cost data from the OpenAI Administration API."""
+        now = datetime.now(timezone.utc)
+
+        def _error_status(msg: str, **extra_fields: object) -> ProviderStatus:
+            extras = dict(extra_fields) if extra_fields else {}
+            return ProviderStatus(
+                provider_name=self.name(),
+                provider_display=self.display_name(),
+                timestamp=now,
+                cached=False,
+                cache_age_seconds=0,
+                errors=[msg],
+                extras=extras,
+            )
+
+        # Resolve admin key
+        try:
+            admin_key = self._resolve_admin_key()
+        except CredentialError as exc:
+            return _error_status(
+                f"Admin key command failed: {exc}\n"
+                "Fix: Check your admin_key_command configuration."
+            )
+
+        if not admin_key:
+            return _error_status(
+                "OpenAI admin key not found.\n"
+                "Fix: Set $OPENAI_ADMIN_KEY or configure admin_key_command\n"
+                "in [providers.openai]. Create an admin key at\n"
+                "platform.openai.com → Settings → Organisation → Admin Keys.\n"
+                "Note: Only Organisation Owners can create admin keys."
+            )
+
+        headers = {
+            "Authorization": f"Bearer {admin_key.get_secret_value()}",
+            "Content-Type": "application/json",
+        }
+
+        # Time range: start of current month to now
+        start_of_month = now.replace(
+            day=1, hour=0, minute=0, second=0, microsecond=0
+        )
+        start_ts = int(start_of_month.timestamp())
+
+        windows: list[UsageWindow] = []
+        model_usage: list[ModelUsage] = []
+        errors: list[str] = []
+        extras: dict = {}
+
+        # Fetch usage (per-model tokens) and costs concurrently
+        usage_data = await self._fetch_endpoint(
+            client,
+            f"{API_BASE}/organization/usage/completions",
+            headers,
+            errors,
+            params={
+                "start_time": str(start_ts),
+                "bucket_width": "1d",
+                "group_by[]": "model",
+            },
+        )
+
+        costs_data = await self._fetch_endpoint(
+            client,
+            f"{API_BASE}/organization/costs",
+            headers,
+            errors,
+            params={
+                "start_time": str(start_ts),
+                "bucket_width": "1d",
+                "group_by[]": "line_item",
+            },
+        )
+
+        # Check for backoff across all endpoints
+        if any("_backoff" in str(e) for e in errors):
+            return ProviderStatus(
+                provider_name=self.name(),
+                provider_display=self.display_name(),
+                timestamp=now,
+                cached=False,
+                cache_age_seconds=0,
+                errors=errors,
+                extras={"_backoff": True},
+            )
+
+        # Parse costs into Spend (MTD) window and per-model costs
+        model_costs: dict[str, float] = {}
+        if costs_data is not None:
+            self._parse_costs(costs_data, windows, model_costs, extras)
+
+        # Parse usage into per-model token counts
+        model_tokens: dict[str, dict] = {}
+        if usage_data is not None:
+            self._parse_usage(usage_data, model_tokens, extras)
+
+        # Merge tokens and costs into ModelUsage entries
+        self._merge_model_data(model_tokens, model_costs, model_usage, extras)
+
+        return ProviderStatus(
+            provider_name=self.name(),
+            provider_display=self.display_name(),
+            timestamp=now,
+            cached=False,
+            cache_age_seconds=0,
+            windows=windows,
+            model_usage=model_usage,
+            extras=extras,
+            errors=errors,
+        )
+
+    # ------------------------------------------------------------------
+    # HTTP helper
+    # ------------------------------------------------------------------
+
+    async def _fetch_endpoint(
+        self,
+        client: httpx.AsyncClient,
+        url: str,
+        headers: dict,
+        errors: list[str],
+        params: dict | None = None,
+    ) -> dict | None:
+        """GET an OpenAI API endpoint, appending errors on failure."""
+        try:
+            resp = await client.get(
+                url,
+                headers=headers,
+                params=params,
+                follow_redirects=False,
+            )
+        except httpx.ConnectError as exc:
+            errors.append(
+                f"Cannot reach api.openai.com: {exc}\n"
+                "Fix: Check your network connection and DNS resolution."
+            )
+            return None
+        except httpx.TimeoutException as exc:
+            errors.append(f"Request to api.openai.com timed out: {exc}")
+            return None
+        except httpx.HTTPError as exc:
+            errors.append(f"HTTP error contacting OpenAI API: {exc}")
+            return None
+
+        if resp.status_code == 401:
+            errors.append(
+                "Authentication failed (HTTP 401).\n"
+                "Your OpenAI admin key may be invalid or revoked.\n"
+                "Fix: Create a new admin key at platform.openai.com →\n"
+                "Settings → Organisation → Admin Keys."
+            )
+            return None
+
+        if resp.status_code == 403:
+            errors.append(
+                "Access denied (HTTP 403).\n"
+                "Your API key may lack the api.usage.read scope.\n"
+                "Fix: Ensure you are using an Admin API Key (sk-admin-*),\n"
+                "not a standard project key (sk-proj-*)."
+            )
+            return None
+
+        if resp.status_code == 429:
+            errors.append(
+                "Rate limited by OpenAI API (HTTP 429).\n"
+                "Cached data will be used until backoff expires. _backoff"
+            )
+            return None
+
+        if resp.status_code != 200:
+            errors.append(
+                f"OpenAI API returned HTTP {resp.status_code}.\n"
+                f"Response: {resp.text[:200]}"
+            )
+            return None
+
+        try:
+            return resp.json()
+        except (ValueError, Exception) as exc:
+            errors.append(f"OpenAI API returned invalid JSON: {exc}")
+            return None
+
+    # ------------------------------------------------------------------
+    # Response parsing
+    # ------------------------------------------------------------------
+
+    def _parse_costs(
+        self,
+        data: dict,
+        windows: list[UsageWindow],
+        model_costs: dict[str, float],
+        extras: dict,
+    ) -> None:
+        """Parse costs response into Spend (MTD) window and per-model costs."""
+        total_spend = 0.0
+
+        for bucket in data.get("data", []):
+            for result in bucket.get("results", []):
+                amount = result.get("amount", {})
+                value = amount.get("value", 0.0)
+                try:
+                    value = float(value)
+                except (ValueError, TypeError):
+                    value = 0.0
+
+                total_spend += value
+
+                line_item = result.get("line_item")
+                if line_item:
+                    model_costs[line_item] = (
+                        model_costs.get(line_item, 0.0) + value
+                    )
+
+        windows.append(
+            UsageWindow(
+                name="Spend (MTD)",
+                utilisation=0.0,
+                resets_at=None,
+                status="normal",
+                unit="usd",
+                raw_value=round(total_spend, 6),
+            )
+        )
+
+    def _parse_usage(
+        self,
+        data: dict,
+        model_tokens: dict[str, dict],
+        extras: dict,
+    ) -> None:
+        """Parse usage/completions response into per-model token dicts."""
+        for bucket in data.get("data", []):
+            for result in bucket.get("results", []):
+                model = result.get("model") or "unknown"
+
+                if model not in model_tokens:
+                    model_tokens[model] = {
+                        "input_tokens": 0,
+                        "output_tokens": 0,
+                        "input_cached_tokens": 0,
+                        "num_model_requests": 0,
+                    }
+
+                entry = model_tokens[model]
+                entry["input_tokens"] += result.get("input_tokens", 0) or 0
+                entry["output_tokens"] += result.get("output_tokens", 0) or 0
+                entry["input_cached_tokens"] += (
+                    result.get("input_cached_tokens", 0) or 0
+                )
+                entry["num_model_requests"] += (
+                    result.get("num_model_requests", 0) or 0
+                )
+
+    def _merge_model_data(
+        self,
+        model_tokens: dict[str, dict],
+        model_costs: dict[str, float],
+        model_usage: list[ModelUsage],
+        extras: dict,
+    ) -> None:
+        """Merge token counts and costs into unified ModelUsage entries."""
+        all_models = sorted(set(model_tokens.keys()) | set(model_costs.keys()))
+
+        for model_name in all_models:
+            tokens = model_tokens.get(model_name, {})
+            cost = model_costs.get(model_name)
+
+            input_t = tokens.get("input_tokens") or None
+            output_t = tokens.get("output_tokens") or None
+            total_t = None
+            if input_t is not None or output_t is not None:
+                total_t = (input_t or 0) + (output_t or 0)
+
+            request_count = tokens.get("num_model_requests") or None
+
+            model_usage.append(
+                ModelUsage(
+                    model=model_name,
+                    input_tokens=input_t,
+                    output_tokens=output_t,
+                    total_tokens=total_t,
+                    cost=cost,
+                    request_count=request_count,
+                    period="mtd",
+                )
+            )
+
+        if all_models:
+            extras["models_used"] = all_models
+
+        # Top model by spend
+        if model_costs:
+            top_model = max(model_costs, key=model_costs.get)  # type: ignore[arg-type]
+            extras["top_model_spend"] = {
+                "model": top_model,
+                "cost": round(model_costs[top_model], 6),
+            }
+
+    # ------------------------------------------------------------------
+    # Metadata
+    # ------------------------------------------------------------------
+
+    def auth_instructions(self) -> str:
+        return (
+            "OpenAI monitoring requires an Admin API Key (sk-admin-*).\n"
+            "1. Go to platform.openai.com → Settings → Organisation → Admin Keys\n"
+            "   (only Organisation Owners can create admin keys)\n"
+            "2. Create an admin key with api.usage.read scope\n"
+            "3. Set $OPENAI_ADMIN_KEY (or configure admin_key_command\n"
+            "   in [providers.openai])"
+        )
+
+    @property
+    def allowed_hosts(self) -> list[str]:
+        return ["api.openai.com"]

--- a/tests/fixtures/openai_costs.json
+++ b/tests/fixtures/openai_costs.json
@@ -1,0 +1,48 @@
+{
+  "object": "page",
+  "data": [
+    {
+      "object": "bucket",
+      "start_time": 1736553600,
+      "end_time": 1736640000,
+      "results": [
+        {
+          "object": "organization.costs.result",
+          "amount": {
+            "value": 1.25,
+            "currency": "usd"
+          },
+          "line_item": "gpt-4o-2024-08-06",
+          "project_id": null
+        },
+        {
+          "object": "organization.costs.result",
+          "amount": {
+            "value": 0.45,
+            "currency": "usd"
+          },
+          "line_item": "gpt-4.1-mini-2025-04-14",
+          "project_id": null
+        }
+      ]
+    },
+    {
+      "object": "bucket",
+      "start_time": 1736640000,
+      "end_time": 1736726400,
+      "results": [
+        {
+          "object": "organization.costs.result",
+          "amount": {
+            "value": 0.98,
+            "currency": "usd"
+          },
+          "line_item": "gpt-4o-2024-08-06",
+          "project_id": null
+        }
+      ]
+    }
+  ],
+  "has_more": false,
+  "next_page": null
+}

--- a/tests/fixtures/openai_usage_completions.json
+++ b/tests/fixtures/openai_usage_completions.json
@@ -1,0 +1,51 @@
+{
+  "object": "page",
+  "data": [
+    {
+      "object": "bucket",
+      "start_time": 1736553600,
+      "end_time": 1736640000,
+      "results": [
+        {
+          "object": "organization.usage.completions.result",
+          "input_tokens": 85000,
+          "output_tokens": 12000,
+          "input_cached_tokens": 5000,
+          "input_audio_tokens": 0,
+          "output_audio_tokens": 0,
+          "num_model_requests": 250,
+          "model": "gpt-4o-2024-08-06"
+        },
+        {
+          "object": "organization.usage.completions.result",
+          "input_tokens": 56000,
+          "output_tokens": 9756,
+          "input_cached_tokens": 0,
+          "input_audio_tokens": 0,
+          "output_audio_tokens": 0,
+          "num_model_requests": 220,
+          "model": "gpt-4.1-mini-2025-04-14"
+        }
+      ]
+    },
+    {
+      "object": "bucket",
+      "start_time": 1736640000,
+      "end_time": 1736726400,
+      "results": [
+        {
+          "object": "organization.usage.completions.result",
+          "input_tokens": 56201,
+          "output_tokens": 8500,
+          "input_cached_tokens": 3000,
+          "input_audio_tokens": 0,
+          "output_audio_tokens": 0,
+          "num_model_requests": 180,
+          "model": "gpt-4o-2024-08-06"
+        }
+      ]
+    }
+  ],
+  "has_more": false,
+  "next_page": null
+}

--- a/tests/providers/test_openai.py
+++ b/tests/providers/test_openai.py
@@ -1,0 +1,579 @@
+"""Tests for the OpenAI provider."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import httpx
+import pytest
+import respx
+
+from llm_monitor.models import ProviderStatus
+from llm_monitor.providers.openai import OpenAIProvider, API_BASE
+
+FIXTURES_DIR = Path(__file__).parent.parent / "fixtures"
+
+ADMIN_KEY = "sk-admin-test-key-value-abcdef1234567890"
+USAGE_URL = f"{API_BASE}/organization/usage/completions"
+COSTS_URL = f"{API_BASE}/organization/costs"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_fixture(name: str) -> dict:
+    return json.loads((FIXTURES_DIR / name).read_text())
+
+
+def _make_config(
+    enabled: bool = True,
+    admin_key_env: str = "OPENAI_ADMIN_KEY",
+) -> dict:
+    return {
+        "providers": {
+            "openai": {
+                "enabled": enabled,
+                "admin_key_env": admin_key_env,
+            },
+        },
+    }
+
+
+def _make_provider(
+    monkeypatch,
+    admin_key: str = ADMIN_KEY,
+    admin_key_env: str = "OPENAI_ADMIN_KEY",
+) -> OpenAIProvider:
+    """Create an OpenAIProvider with env-based credentials."""
+    if admin_key:
+        monkeypatch.setenv(admin_key_env, admin_key)
+    config = _make_config(admin_key_env=admin_key_env)
+    return OpenAIProvider(config)
+
+
+def _mock_all_endpoints(
+    usage: dict | None = None,
+    costs: dict | None = None,
+) -> None:
+    """Set up respx mocks for all OpenAI endpoints."""
+    respx.get(USAGE_URL).respond(
+        200, json=usage or _load_fixture("openai_usage_completions.json")
+    )
+    respx.get(COSTS_URL).respond(
+        200, json=costs or _load_fixture("openai_costs.json")
+    )
+
+
+# ---------------------------------------------------------------------------
+# Metadata
+# ---------------------------------------------------------------------------
+
+
+class TestMetadata:
+    def test_name(self):
+        provider = OpenAIProvider(_make_config())
+        assert provider.name() == "openai"
+
+    def test_display_name(self):
+        provider = OpenAIProvider(_make_config())
+        assert provider.display_name() == "OpenAI"
+
+    def test_auth_instructions(self):
+        provider = OpenAIProvider(_make_config())
+        instructions = provider.auth_instructions()
+        assert "Admin API Key" in instructions
+        assert "platform.openai.com" in instructions
+        assert "OPENAI_ADMIN_KEY" in instructions
+
+    def test_allowed_hosts(self):
+        provider = OpenAIProvider(_make_config())
+        assert provider.allowed_hosts == ["api.openai.com"]
+
+
+# ---------------------------------------------------------------------------
+# Credential resolution
+# ---------------------------------------------------------------------------
+
+
+class TestCredentialResolution:
+    def test_admin_key_from_env(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_ADMIN_KEY", ADMIN_KEY)
+        provider = OpenAIProvider(_make_config())
+        key = provider._resolve_admin_key()
+        assert key is not None
+        assert key.get_secret_value() == ADMIN_KEY
+
+    def test_admin_key_custom_env_var(self, monkeypatch):
+        monkeypatch.setenv("MY_OPENAI_KEY", ADMIN_KEY)
+        config = _make_config(admin_key_env="MY_OPENAI_KEY")
+        provider = OpenAIProvider(config)
+        key = provider._resolve_admin_key()
+        assert key is not None
+        assert key.get_secret_value() == ADMIN_KEY
+
+    def test_admin_key_not_found(self, monkeypatch):
+        monkeypatch.delenv("OPENAI_ADMIN_KEY", raising=False)
+        provider = OpenAIProvider(_make_config())
+        key = provider._resolve_admin_key()
+        assert key is None
+
+    def test_admin_key_repr_masked(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_ADMIN_KEY", ADMIN_KEY)
+        provider = OpenAIProvider(_make_config())
+        key = provider._resolve_admin_key()
+        assert "sk-admin" not in repr(key)
+        assert "***" in repr(key)
+
+
+# ---------------------------------------------------------------------------
+# is_configured
+# ---------------------------------------------------------------------------
+
+
+class TestIsConfigured:
+    def test_configured_with_admin_key(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_ADMIN_KEY", ADMIN_KEY)
+        provider = OpenAIProvider(_make_config())
+        assert provider.is_configured() is True
+
+    def test_not_configured_without_key(self, monkeypatch):
+        monkeypatch.delenv("OPENAI_ADMIN_KEY", raising=False)
+        provider = OpenAIProvider(_make_config())
+        assert provider.is_configured() is False
+
+
+# ---------------------------------------------------------------------------
+# fetch_usage — full response
+# ---------------------------------------------------------------------------
+
+
+class TestFetchUsage:
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_full_response(self, monkeypatch):
+        provider = _make_provider(monkeypatch)
+        _mock_all_endpoints()
+
+        async with httpx.AsyncClient() as client:
+            status = await provider.fetch_usage(client)
+
+        assert isinstance(status, ProviderStatus)
+        assert status.provider_name == "openai"
+        assert status.provider_display == "OpenAI"
+        assert status.errors == []
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_spend_mtd_window(self, monkeypatch):
+        """Costs across all buckets sum to a single Spend (MTD) window."""
+        provider = _make_provider(monkeypatch)
+        _mock_all_endpoints()
+
+        async with httpx.AsyncClient() as client:
+            status = await provider.fetch_usage(client)
+
+        spend_windows = [w for w in status.windows if w.name == "Spend (MTD)"]
+        assert len(spend_windows) == 1
+
+        spend = spend_windows[0]
+        assert spend.unit == "usd"
+        # 1.25 + 0.45 + 0.98 = 2.68
+        assert spend.raw_value == pytest.approx(2.68, abs=0.01)
+        assert spend.status == "normal"
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_per_model_usage(self, monkeypatch):
+        """Usage endpoint populates per-model token counts."""
+        provider = _make_provider(monkeypatch)
+        _mock_all_endpoints()
+
+        async with httpx.AsyncClient() as client:
+            status = await provider.fetch_usage(client)
+
+        models = {m.model: m for m in status.model_usage}
+        assert "gpt-4o-2024-08-06" in models
+        assert "gpt-4.1-mini-2025-04-14" in models
+
+        gpt4o = models["gpt-4o-2024-08-06"]
+        # 85000 + 56201 = 141201 (across two buckets)
+        assert gpt4o.input_tokens == 141201
+        # 12000 + 8500 = 20500
+        assert gpt4o.output_tokens == 20500
+        assert gpt4o.total_tokens == 141201 + 20500
+        # 250 + 180 = 430
+        assert gpt4o.request_count == 430
+
+        mini = models["gpt-4.1-mini-2025-04-14"]
+        assert mini.input_tokens == 56000
+        assert mini.output_tokens == 9756
+        assert mini.request_count == 220
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_per_model_costs(self, monkeypatch):
+        """Costs endpoint populates per-model cost in USD."""
+        provider = _make_provider(monkeypatch)
+        _mock_all_endpoints()
+
+        async with httpx.AsyncClient() as client:
+            status = await provider.fetch_usage(client)
+
+        models = {m.model: m for m in status.model_usage}
+
+        gpt4o = models["gpt-4o-2024-08-06"]
+        # 1.25 + 0.98 = 2.23
+        assert gpt4o.cost == pytest.approx(2.23, abs=0.01)
+        assert gpt4o.period == "mtd"
+
+        mini = models["gpt-4.1-mini-2025-04-14"]
+        assert mini.cost == pytest.approx(0.45, abs=0.01)
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_models_used_extras(self, monkeypatch):
+        """Extras dict includes sorted models_used list."""
+        provider = _make_provider(monkeypatch)
+        _mock_all_endpoints()
+
+        async with httpx.AsyncClient() as client:
+            status = await provider.fetch_usage(client)
+
+        assert "models_used" in status.extras
+        assert status.extras["models_used"] == [
+            "gpt-4.1-mini-2025-04-14",
+            "gpt-4o-2024-08-06",
+        ]
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_top_model_spend_extras(self, monkeypatch):
+        """Extras dict includes top_model_spend."""
+        provider = _make_provider(monkeypatch)
+        _mock_all_endpoints()
+
+        async with httpx.AsyncClient() as client:
+            status = await provider.fetch_usage(client)
+
+        assert "top_model_spend" in status.extras
+        top = status.extras["top_model_spend"]
+        assert top["model"] == "gpt-4o-2024-08-06"
+        assert top["cost"] == pytest.approx(2.23, abs=0.01)
+
+
+# ---------------------------------------------------------------------------
+# Token + cost merge
+# ---------------------------------------------------------------------------
+
+
+class TestModelMerge:
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_cost_only_model(self, monkeypatch):
+        """A model in costs but not usage still gets a ModelUsage entry."""
+        provider = _make_provider(monkeypatch)
+
+        # Usage has only gpt-4o, costs has gpt-4o + text-embedding
+        usage = {
+            "object": "page",
+            "data": [{
+                "object": "bucket",
+                "start_time": 1736553600,
+                "end_time": 1736640000,
+                "results": [{
+                    "object": "organization.usage.completions.result",
+                    "input_tokens": 100,
+                    "output_tokens": 50,
+                    "input_cached_tokens": 0,
+                    "input_audio_tokens": 0,
+                    "output_audio_tokens": 0,
+                    "num_model_requests": 1,
+                    "model": "gpt-4o-2024-08-06",
+                }],
+            }],
+            "has_more": False,
+            "next_page": None,
+        }
+        costs = {
+            "object": "page",
+            "data": [{
+                "object": "bucket",
+                "start_time": 1736553600,
+                "end_time": 1736640000,
+                "results": [
+                    {
+                        "object": "organization.costs.result",
+                        "amount": {"value": 0.01, "currency": "usd"},
+                        "line_item": "gpt-4o-2024-08-06",
+                        "project_id": None,
+                    },
+                    {
+                        "object": "organization.costs.result",
+                        "amount": {"value": 0.005, "currency": "usd"},
+                        "line_item": "text-embedding-3-small",
+                        "project_id": None,
+                    },
+                ],
+            }],
+            "has_more": False,
+            "next_page": None,
+        }
+
+        _mock_all_endpoints(usage=usage, costs=costs)
+
+        async with httpx.AsyncClient() as client:
+            status = await provider.fetch_usage(client)
+
+        models = {m.model: m for m in status.model_usage}
+        assert "text-embedding-3-small" in models
+        embedding = models["text-embedding-3-small"]
+        assert embedding.cost == pytest.approx(0.005)
+        assert embedding.input_tokens is None
+        assert embedding.output_tokens is None
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_usage_only_model(self, monkeypatch):
+        """A model in usage but not costs gets None cost."""
+        provider = _make_provider(monkeypatch)
+
+        usage = {
+            "object": "page",
+            "data": [{
+                "object": "bucket",
+                "start_time": 1736553600,
+                "end_time": 1736640000,
+                "results": [{
+                    "object": "organization.usage.completions.result",
+                    "input_tokens": 100,
+                    "output_tokens": 50,
+                    "input_cached_tokens": 0,
+                    "input_audio_tokens": 0,
+                    "output_audio_tokens": 0,
+                    "num_model_requests": 5,
+                    "model": "gpt-4o-2024-08-06",
+                }],
+            }],
+            "has_more": False,
+            "next_page": None,
+        }
+        costs = {
+            "object": "page",
+            "data": [],
+            "has_more": False,
+            "next_page": None,
+        }
+
+        _mock_all_endpoints(usage=usage, costs=costs)
+
+        async with httpx.AsyncClient() as client:
+            status = await provider.fetch_usage(client)
+
+        models = {m.model: m for m in status.model_usage}
+        gpt4o = models["gpt-4o-2024-08-06"]
+        assert gpt4o.input_tokens == 100
+        assert gpt4o.cost is None
+
+
+# ---------------------------------------------------------------------------
+# Multi-bucket aggregation
+# ---------------------------------------------------------------------------
+
+
+class TestMultiBucketAggregation:
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_tokens_summed_across_buckets(self, monkeypatch):
+        """Token counts are summed across multiple time buckets."""
+        provider = _make_provider(monkeypatch)
+        _mock_all_endpoints()
+
+        async with httpx.AsyncClient() as client:
+            status = await provider.fetch_usage(client)
+
+        models = {m.model: m for m in status.model_usage}
+        gpt4o = models["gpt-4o-2024-08-06"]
+        # Bucket 1: 85000 input, bucket 2: 56201 input
+        assert gpt4o.input_tokens == 85000 + 56201
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_costs_summed_across_buckets(self, monkeypatch):
+        """Costs are summed across multiple time buckets for total spend."""
+        provider = _make_provider(monkeypatch)
+        _mock_all_endpoints()
+
+        async with httpx.AsyncClient() as client:
+            status = await provider.fetch_usage(client)
+
+        spend = next(w for w in status.windows if w.name == "Spend (MTD)")
+        # 1.25 + 0.45 + 0.98 = 2.68
+        assert spend.raw_value == pytest.approx(2.68, abs=0.01)
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_empty_buckets(self, monkeypatch):
+        """Empty data arrays produce zero spend and no models."""
+        provider = _make_provider(monkeypatch)
+        empty = {
+            "object": "page",
+            "data": [],
+            "has_more": False,
+            "next_page": None,
+        }
+        _mock_all_endpoints(usage=empty, costs=empty)
+
+        async with httpx.AsyncClient() as client:
+            status = await provider.fetch_usage(client)
+
+        assert status.errors == []
+        spend = next(w for w in status.windows if w.name == "Spend (MTD)")
+        assert spend.raw_value == pytest.approx(0.0)
+        assert status.model_usage == []
+        assert "models_used" not in status.extras
+
+
+# ---------------------------------------------------------------------------
+# Error handling
+# ---------------------------------------------------------------------------
+
+
+class TestErrorHandling:
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_missing_admin_key(self, monkeypatch):
+        monkeypatch.delenv("OPENAI_ADMIN_KEY", raising=False)
+        provider = OpenAIProvider(_make_config())
+
+        async with httpx.AsyncClient() as client:
+            status = await provider.fetch_usage(client)
+
+        assert len(status.errors) == 1
+        assert "admin key not found" in status.errors[0]
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_401_unauthorized(self, monkeypatch):
+        provider = _make_provider(monkeypatch)
+        respx.get(USAGE_URL).respond(401)
+        respx.get(COSTS_URL).respond(401)
+
+        async with httpx.AsyncClient() as client:
+            status = await provider.fetch_usage(client)
+
+        assert any("401" in e for e in status.errors)
+        assert any("invalid or revoked" in e for e in status.errors)
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_403_forbidden(self, monkeypatch):
+        provider = _make_provider(monkeypatch)
+        respx.get(USAGE_URL).respond(403)
+        respx.get(COSTS_URL).respond(403)
+
+        async with httpx.AsyncClient() as client:
+            status = await provider.fetch_usage(client)
+
+        assert any("403" in e for e in status.errors)
+        assert any("api.usage.read" in e for e in status.errors)
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_429_backoff(self, monkeypatch):
+        provider = _make_provider(monkeypatch)
+        respx.get(USAGE_URL).respond(429)
+        respx.get(COSTS_URL).respond(429)
+
+        async with httpx.AsyncClient() as client:
+            status = await provider.fetch_usage(client)
+
+        assert any("429" in e for e in status.errors)
+        assert status.extras.get("_backoff") is True
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_500_server_error(self, monkeypatch):
+        provider = _make_provider(monkeypatch)
+        respx.get(USAGE_URL).respond(500, text="Internal Server Error")
+        respx.get(COSTS_URL).respond(500, text="Internal Server Error")
+
+        async with httpx.AsyncClient() as client:
+            status = await provider.fetch_usage(client)
+
+        assert any("500" in e for e in status.errors)
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_network_error(self, monkeypatch):
+        provider = _make_provider(monkeypatch)
+        respx.get(USAGE_URL).mock(side_effect=httpx.ConnectError("DNS failed"))
+        respx.get(COSTS_URL).mock(side_effect=httpx.ConnectError("DNS failed"))
+
+        async with httpx.AsyncClient() as client:
+            status = await provider.fetch_usage(client)
+
+        assert any("Cannot reach api.openai.com" in e for e in status.errors)
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_timeout_error(self, monkeypatch):
+        provider = _make_provider(monkeypatch)
+        respx.get(USAGE_URL).mock(
+            side_effect=httpx.ReadTimeout("Read timed out")
+        )
+        respx.get(COSTS_URL).mock(
+            side_effect=httpx.ReadTimeout("Read timed out")
+        )
+
+        async with httpx.AsyncClient() as client:
+            status = await provider.fetch_usage(client)
+
+        assert any("timed out" in e for e in status.errors)
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_partial_failure(self, monkeypatch):
+        """Usage succeeds but costs fails — still returns usage data."""
+        provider = _make_provider(monkeypatch)
+        respx.get(USAGE_URL).respond(
+            200,
+            json=_load_fixture("openai_usage_completions.json"),
+        )
+        respx.get(COSTS_URL).respond(500, text="Error")
+
+        async with httpx.AsyncClient() as client:
+            status = await provider.fetch_usage(client)
+
+        # Should have errors from costs endpoint
+        assert len(status.errors) > 0
+        # But model_usage should still be populated from usage endpoint
+        assert len(status.model_usage) > 0
+        # Spend window should still be created (with 0.0)
+        spend = next(
+            (w for w in status.windows if w.name == "Spend (MTD)"), None
+        )
+        assert spend is None  # No costs data → no spend window
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_admin_key_command_failure(self, monkeypatch):
+        """key_command failure raises CredentialError → error status."""
+        monkeypatch.delenv("OPENAI_ADMIN_KEY", raising=False)
+        config = {
+            "providers": {
+                "openai": {
+                    "enabled": True,
+                    "admin_key_command": "false",  # exits non-zero
+                },
+            },
+        }
+        provider = OpenAIProvider(config)
+
+        async with httpx.AsyncClient() as client:
+            status = await provider.fetch_usage(client)
+
+        assert len(status.errors) == 1
+        assert "command failed" in status.errors[0].lower()


### PR DESCRIPTION
## Summary

- **OpenAI provider** (`providers/openai.py`) — organisation-level spend and per-model usage monitoring via the Administration API
  - Usage API: `GET /v1/organization/usage/completions` with `group_by=model` for per-model token counts (input, output, cached, requests)
  - Costs API: `GET /v1/organization/costs` with `group_by=line_item` for per-model cost and total MTD spend
  - Admin key credential resolution via `$OPENAI_ADMIN_KEY` (`sk-admin-*`) with 4-tier chain
  - Token + cost merge into unified `ModelUsage` entries
- **Config and registration** — `providers.openai` section with `admin_key_env`, provider registered in `__init__.py`
- **30 passing tests** — metadata, credential resolution, is_configured, full response parsing, per-model usage/costs, token+cost merge, multi-bucket aggregation, error handling (401/403/429/5xx/network/timeout/partial failure/key_command failure)
- **SPEC.md updated** — Section 3.3 rewritten with admin key auth, response schemas, query parameters; OQ-012 closed, A-006 falsified, D-052 added; v0.6.0 checklist expanded
- **CHANGELOG.md** — added with summaries for all completed versions (v0.1.0–v0.5.0)
- **README.md** — OpenAI prerequisites, config example, credential setup

Closes #6

## Test plan

- [x] All 30 OpenAI provider tests pass
- [x] Full test suite passes (360 tests, excluding pre-existing daemon test hang)
- [ ] Manual verification with a real admin key (requires org owner access)

🤖 Generated with [Claude Code](https://claude.com/claude-code)