### PR TITLE
feat: v0.7.1 Claude extra usage spend tracking (alpha)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to llm-monitor are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.1] - 2026-04-10
+
+### Added
+
+- **Claude extra usage spend** (alpha) — tracks dollar spend beyond the subscription cap via undocumented `extra_usage` field in `/api/oauth/usage` response
+- Extra Usage window with percentage utilisation, raw spend and limit in user's billing currency
+- `extras` dict includes `extra_usage_enabled`, `extra_usage_spent`, `extra_usage_limit`
+- **Weekly Sonnet (7d)** window — new per-model utilisation window from Claude API (`seven_day_sonnet`)
+- **`credits` unit type** in formatters — displays as `$X.XX` with no currency qualifier, for values in the user's billing currency
+- Alpha warning utility (`emit_alpha_warning`) extracted to `config.py` as shared infrastructure for all alpha providers
+
+### Changed
+
+- Claude test fixture updated with `seven_day_sonnet`, `seven_day_cowork`, and `extra_usage` fields matching current API response
+- OQ-001, OQ-002, OQ-004, OQ-008 closed with research findings in SPEC.md
+
 ## [0.7.0] - 2026-04-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -216,11 +216,20 @@ api_key_env = "OLLAMA_API_KEY"     # default, can be omitted
 
 Local instance monitoring (models loaded, VRAM, health) is **not** an alpha feature — it uses stable, documented APIs and works without `enable_alpha_features`.
 
-### Claude Extra Usage Spend (planned — v0.7.1, [#19](https://github.com/danielithomas/llm-monitor/issues/19))
+### Claude Extra Usage Spend (v0.7.1)
 
-Tracks dollar spend for Claude usage beyond the subscription cap. No additional credentials needed — uses the existing Claude Code OAuth token.
+Tracks dollar spend for Claude usage beyond the subscription cap. No additional credentials needed — uses the existing Claude Code OAuth token. Enable alpha features in your config:
 
-**Why alpha?** No REST API exists for extra usage data. The implementation will use undocumented endpoints or web scraping. It will graduate to stable when Anthropic exposes an official endpoint.
+```toml
+[general]
+enable_alpha_features = true
+```
+
+**What it monitors:**
+- Extra usage spend vs monthly limit (percentage + dollar amounts)
+- Whether extra usage is enabled on your account
+
+**Why alpha?** The extra usage data comes from an undocumented field in the Claude usage API. It could change without notice. It will graduate to stable when Anthropic formally documents the endpoint.
 
 ## Configuration
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -384,11 +384,35 @@ The backoff state is persisted in the provider's cache file so it survives proce
 - Claude Code manages token refresh automatically; llm-monitor is a read-only consumer (see Section 7.7).
 - On token expiry, the tool emits a clear error directing the user to run `claude /login`.
 
-**Extra usage spend:** No REST endpoint exists. Deferred (see OQ-001).
+**Extra usage spend (alpha — D-053, v0.7.1):** The existing `/api/oauth/usage` endpoint returns an `extra_usage` object when extra usage is enabled on the account:
 
-**Extras dict:** `{ "plan": null, "extra_usage_enabled": null }` (plan detection deferred to OQ-006).
+```json
+{
+  "extra_usage": {
+    "is_enabled": true,
+    "monthly_limit": 10000,
+    "used_credits": 10010.0,
+    "utilization": 100.0
+  }
+}
+```
 
-**Per-model breakdown:** The Claude usage endpoint does not provide a per-model token breakdown. The `seven_day_opus` window provides an Opus-specific utilisation percentage, which is mapped as a separate `UsageWindow`. The `model_usage` list will contain an entry for Opus (derived from the Opus window) but Sonnet usage can only be inferred as the difference between the all-models weekly window and the Opus window. If Anthropic expands the endpoint to include per-model detail, the provider will populate `model_usage` accordingly.
+- `is_enabled`: whether the account has extra usage turned on
+- `monthly_limit`: spending cap in cents (user's billing currency, not necessarily USD)
+- `used_credits`: amount consumed in cents (`used_credits` can exceed `monthly_limit`)
+- `utilization`: percentage of limit consumed (0–100%)
+
+Since the endpoint is undocumented and the `extra_usage` field could be removed or changed without notice, this is gated behind `enable_alpha_features` (D-053). The currency is the user's billing currency (no currency identifier in the API response), so values are displayed with a generic `$` symbol using the `"credits"` unit type.
+
+**Mapped extra usage window (alpha):**
+
+| Window | Source | Unit | Notes |
+|--------|--------|------|-------|
+| Extra Usage | `extra_usage.utilization` | percent | Percentage of monthly limit consumed. `raw_value` = `used_credits / 100`, `raw_limit` = `monthly_limit / 100`. Only when `is_enabled` and alpha flag set. |
+
+**Extras dict:** `{ "extra_usage_enabled": true/false/null, "extra_usage_spent": 100.10, "extra_usage_limit": 100.00 }` (dollar values derived from cents). `extra_usage_enabled` is `null` when `extra_usage` is absent from the response. Spend/limit fields only present when extra usage is enabled and alpha flag is set.
+
+**Per-model breakdown:** The Claude usage endpoint does not provide a per-model token breakdown. The `seven_day_opus` and `seven_day_sonnet` windows provide per-model utilisation percentages, which are mapped as separate `UsageWindow` entries. If Anthropic expands the endpoint to include per-model detail, the provider will populate `model_usage` accordingly.
 
 **Allowed hosts:** `api.anthropic.com` (HTTPS only).
 
@@ -2005,14 +2029,14 @@ The JSON output schema (Section 4.2.3) and config file format (Section 4.6) are 
 
 | ID | Question | Impact | Relates To | Status |
 |----|----------|--------|------------|--------|
-| OQ-001 | **How to surface Claude extra usage spend data?** No REST API exists. Options: (a) Playwright scrape of `claude.ai/settings/usage`; (b) leave as "not available" with web link; (c) wait for Anthropic to expose an endpoint; **(d) ship behind `enable_alpha_features` flag (D-053) using undocumented endpoints or scraping, with clear warnings.** | High | Claude | Open — leaning towards (d) |
-| OQ-002 | **Is the `/api/oauth/usage` endpoint stable enough to depend on?** Undocumented, aggressively rate-limited. Could change or be removed. | High | Claude | Open |
+| ~~OQ-001~~ | ~~**How to surface Claude extra usage spend data?**~~ The existing `/api/oauth/usage` endpoint already returns an `extra_usage` object with `is_enabled`, `monthly_limit` (cents in user's billing currency), `used_credits`, and `utilization` (0–100%). No scraping needed. Ship behind `enable_alpha_features` (D-053) since the endpoint is undocumented. | High | Claude | **Closed (v0.7.1 research):** Data is in the existing endpoint response. Parse `extra_usage` field. |
+| ~~OQ-002~~ | ~~**Is the `/api/oauth/usage` endpoint stable enough to depend on?**~~ Undocumented and aggressively rate-limited (~5 requests per token, then persistent 429s with no `Retry-After`). Anthropic closed bug reports as NOT_PLANNED. The existing provider already depends on it with exponential backoff — extra usage parsing adds no additional API calls. | High | Claude | **Closed (v0.7.1 research):** Already depended upon. Backoff handles rate limits. |
 | OQ-003 | **Should Claude token refresh be self-managed or rely on Claude Code?** Self-refreshing is more robust but adds complexity and credential file conflict risk. | Medium | Claude | **Closed (D-036):** Read-only consumer. Self-refresh introduces race conditions with Claude Code's Node.js process. |
-| OQ-004 | **What is the actual rate limit on the Claude usage endpoint?** No documentation exists. Empirical testing needed. | Medium | Claude | Open |
+| ~~OQ-004~~ | ~~**What is the actual rate limit on the Claude usage endpoint?**~~ Approximately 5 requests per access token, then persistent 429s. No `Retry-After` header. Refreshing the token resets the counter but disrupts Claude Code's session. Community issues: [#31021](https://github.com/anthropics/claude-code/issues/31021), [#31637](https://github.com/anthropics/claude-code/issues/31637). | Medium | Claude | **Closed (v0.7.1 research):** ~5 req/token, handled by existing backoff. |
 | OQ-005 | **Multi-account support?** Should the tool support multiple credentials per provider (e.g., work vs personal Claude accounts)? | Low (v1) | All | Open |
 | OQ-006 | **Claude plan detection?** The usage endpoint doesn't return plan type (Pro, Max5, Max20). Infer from thresholds or require user config? | Low | Claude | Open |
 | ~~OQ-007~~ | ~~**Tmux/status-bar integration format?** A `--compact` single-line output could feed tmux `status-right`, polybar, waybar. What format is most useful?~~ | ~~Low (v1)~~ | ~~Output~~ | **Closed (D-045):** `--compact` is a `--monitor`-only modifier rendering one plain-text line per provider. Tmux polling uses `--now` with external formatting. No JSON waybar variant in v0.4.0. |
-| OQ-008 | **What does `utilization > 100` look like in Claude's API?** Does it exceed 100 when using extra usage, or cap at 100 with a separate indicator? | Medium | Claude | Open |
+| ~~OQ-008~~ | ~~**What does `utilization > 100` look like in Claude's API?**~~ Extra usage has its own `extra_usage.utilization` field (0–100%, capped at cap). `used_credits` can exceed `monthly_limit` (e.g. 10010 > 10000). The subscription windows (`five_hour`, `seven_day`) remain separate percentage fields unaffected by extra usage. | Medium | Claude | **Closed (v0.7.1 research):** Separate `extra_usage` object, `used_credits` can exceed `monthly_limit`. |
 | OQ-009 | **GTK4 vs GTK3 for v2?** GTK4 + libadwaita is modern GNOME, but AppIndicator3 is GTK3. May need bridging or alternative tray approach. | Medium (v2) | GTK | Open |
 | ~~OQ-010~~ | ~~**Licensing?** MIT vs GPL. MIT is simpler; GPL aligns with GNOME ecosystem.~~ | ~~Low~~ | ~~All~~ | **Closed:** MIT license committed to repo. `pyproject.toml` updated accordingly. |
 | ~~OQ-011~~ | ~~**Does xAI have a programmatic billing/usage API?** Console shows spend, but no documented REST endpoint for querying balance or MTD cost found. Rate limit headers provide per-request data only.~~ | ~~High~~ | ~~Grok~~ | **Closed:** Yes. The xAI Management API (`management-api.x.ai`) provides full billing, spend, usage analytics, prepaid balance, and spending limit endpoints. Requires a separate Management Key (not the inference API key) and team ID. See updated Section 3.2. |
@@ -2064,7 +2088,7 @@ The JSON output schema (Section 4.2.3) and config file format (Section 4.6) are 
 | D-002 | **Pluggable provider architecture with abstract base class.** | Enables incremental delivery (Claude first, others later) without refactoring core. Third-party providers possible in future. | 2026-04-05 | Accepted |
 | D-003 | **JSON as default output mode (no flag required).** | Unix philosophy - default output is machine-parseable. Human-readable output is opt-in via `--now` or `--monitor`. | 2026-04-05 | Accepted |
 | D-004 | **Global poll interval (10m default) with per-provider override.** | Cloud usage data changes slowly; 10 minutes is sufficient for Claude, OpenAI, Grok, and avoids Claude's aggressive rate limiting. Local providers (Ollama, Local) override to 60s. A single `poll_interval` replaces the former `cache_ttl` + `refresh_interval` split. | 2026-04-06 | Accepted |
-| D-005 | **Claude extra usage spend available as alpha feature.** | No clean API exists. Scraping is fragile. The utilisation percentages cover the primary use case. However, rather than deferring indefinitely, this can ship behind `enable_alpha_features` (D-053). Alpha implementation may use undocumented endpoints or scraping, with clear warnings. Graduates to stable when Anthropic exposes an official endpoint. See OQ-001. Tracked as [#19](https://github.com/danielithomas/llm-monitor/issues/19) for v0.7.1. | 2026-04-10 | Accepted |
+| D-005 | **Claude extra usage spend available as alpha feature.** | The existing `/api/oauth/usage` endpoint returns an `extra_usage` object with `is_enabled`, `monthly_limit` (cents), `used_credits`, and `utilization` (0–100%). No scraping needed — just parse an additional field from the existing response. Gated behind `enable_alpha_features` (D-053) since the endpoint is undocumented. Values are in the user's billing currency (not necessarily USD), displayed using `"credits"` unit type. Graduates to stable when Anthropic documents the endpoint. See OQ-001. Tracked as [#19](https://github.com/danielithomas/llm-monitor/issues/19) for v0.7.1. | 2026-04-10 | Accepted |
 | D-006 | **Use `rich` for terminal output.** | Progress bars, tables, colour, Live display with minimal code. Widely used, well-maintained. | 2026-04-05 | Accepted |
 | D-007 | **Follow XDG Base Directory specification.** | Config in `~/.config/llm-monitor/`, cache in `~/.cache/llm-monitor/`. Standard Linux practice. | 2026-04-05 | Accepted |
 | D-008 | **Lightweight base install with additive extras.** | Base install includes cloud providers only (no compiled C extensions). `[local]` adds psutil/pynvml for GPU metrics. `[gtk]` adds PyGObject. `[all]` adds everything. Extras are additive, not subtractive — this is how pip extras actually work. | 2026-04-05 | Accepted |
@@ -2426,6 +2450,34 @@ The JSON output schema (Section 4.2.3) and config file format (Section 4.6) are 
 
 **Documentation:**
 - [x] README.md update — add Ollama to supported providers list, single-host and multi-host configuration examples, VRAM and RAM monitoring explanation, no credentials required note for local, cloud usage monitoring as alpha feature with setup instructions
+
+### v0.7.1 - Claude Extra Usage Spend (Alpha)
+
+**Core (behind `enable_alpha_features`, D-053):**
+- [x] Parse `extra_usage` object from `/api/oauth/usage` response (`is_enabled`, `monthly_limit`, `used_credits`, `utilization`)
+- [x] Create "Extra Usage" `UsageWindow` with `unit="percent"`, `raw_value` (spent in dollars), `raw_limit` (limit in dollars) — only when `is_enabled` and alpha flag set
+- [x] Populate extras dict with `extra_usage_enabled`, `extra_usage_spent`, `extra_usage_limit`
+- [x] Skip gracefully when `extra_usage` is `null` or absent from response
+- [x] Alpha feature stderr warning reuses existing `_emit_alpha_warning` pattern from Ollama provider (extract to shared utility)
+
+**New response fields:**
+- [x] Parse `seven_day_sonnet` window (new per-model window, same structure as `seven_day_opus`)
+- [x] Handle `seven_day_cowork` window if non-null (shared/team usage)
+
+**Formatters:**
+- [x] Add `"credits"` unit support to `table_fmt.py` `_format_value_and_reset()` — display as `$X.XX` (generic dollar, no currency qualifier)
+- [x] Add `"credits"` unit support to `table_fmt.py` bar rendering — no percentage bar for credits
+- [x] Add `"credits"` unit support to `monitor_fmt.py` `_build_provider_panel()` — display as `$X.XX`
+- [x] Add `"credits"` unit support to `monitor_fmt.py` `format_compact_line()` — display as `$X.XX`
+
+**Tests:**
+- [x] `test_providers/test_claude.py` — extra usage parsing (enabled, disabled, absent), alpha gating, `used_credits` exceeding `monthly_limit`, cents-to-dollars conversion, extras dict population
+- [x] `test_providers/test_claude.py` — `seven_day_sonnet` window parsing
+- [x] `test_formatters/` or existing formatter tests — `"credits"` unit renders as `$X.XX` in table and monitor
+
+**Documentation:**
+- [x] README.md alpha features section — update Claude extra usage description from "planned" to active, add setup instructions
+- [x] CHANGELOG.md entry
 
 ### v0.8.0 - Local System Metrics Provider
 

--- a/src/llm_monitor/config.py
+++ b/src/llm_monitor/config.py
@@ -175,6 +175,22 @@ def is_alpha_enabled(config: dict) -> bool:
     return bool(config.get("general", {}).get("enable_alpha_features", False))
 
 
+# Module-level flag: emit the alpha warning at most once per process.
+_alpha_warning_emitted = False
+
+
+def emit_alpha_warning() -> None:
+    """Print a one-time alpha feature warning to stderr."""
+    global _alpha_warning_emitted
+    if not _alpha_warning_emitted:
+        print(
+            "Warning: Alpha features are enabled. Some data sources are "
+            "unstable and may break between releases.",
+            file=sys.stderr,
+        )
+        _alpha_warning_emitted = True
+
+
 def _deep_merge(base: dict, override: dict) -> dict:
     """Recursively merge *override* into a copy of *base*.
 

--- a/src/llm_monitor/formatters/monitor_fmt.py
+++ b/src/llm_monitor/formatters/monitor_fmt.py
@@ -140,6 +140,10 @@ def format_compact_line(
             val_str = f" ${val:,.2f}"
             line.append_text(bar)
             line.append(val_str, style=STATUS_COLOURS.get(w.status, "white"))
+        elif w.unit == "credits":
+            bar = Text(" " * _COMPACT_BAR_WIDTH)
+            line.append_text(bar)
+            line.append(f" ${val:,.2f}", style=STATUS_COLOURS.get(w.status, "white"))
         elif w.unit == "count":
             bar = Text(" " * _COMPACT_BAR_WIDTH)
             line.append_text(bar)
@@ -208,6 +212,9 @@ def _build_provider_panel(
         style = STATUS_COLOURS.get(window.status, "white")
         val = window.raw_value or 0.0
         if window.unit == "usd":
+            bar = Text(" " * _BAR_WIDTH)
+            pct = Text(f"${val:,.2f}", style=style)
+        elif window.unit == "credits":
             bar = Text(" " * _BAR_WIDTH)
             pct = Text(f"${val:,.2f}", style=style)
         elif window.unit == "count":

--- a/src/llm_monitor/formatters/table_fmt.py
+++ b/src/llm_monitor/formatters/table_fmt.py
@@ -58,6 +58,8 @@ def _format_value_and_reset(window: UsageWindow) -> str:
     val = window.raw_value or 0.0
     if window.unit == "usd":
         formatted = f"${val:,.2f}"
+    elif window.unit == "credits":
+        formatted = f"${val:,.2f}"
     elif window.unit == "count":
         formatted = f"{int(val)}"
     elif window.unit == "mb":
@@ -126,7 +128,7 @@ def format_table(
         # Window rows
         for window in status.windows:
             name_text = Text(f"  {window.name}")
-            if window.unit in ("usd", "count", "mb"):
+            if window.unit in ("usd", "credits", "count", "mb"):
                 bar = Text(" " * _BAR_WIDTH)
             else:
                 bar = _build_bar(window.utilisation, window.status, colour)

--- a/src/llm_monitor/providers/claude.py
+++ b/src/llm_monitor/providers/claude.py
@@ -10,6 +10,7 @@ from typing import Optional
 
 import httpx
 
+from llm_monitor.config import emit_alpha_warning, is_alpha_enabled
 from llm_monitor.models import ProviderStatus, SecretStr, UsageWindow, compute_status
 from llm_monitor.providers.base import Provider
 from llm_monitor.providers import register_provider
@@ -209,6 +210,7 @@ class ClaudeProvider(Provider):
 
         thresholds = self._config.get("thresholds")
         windows = self._parse_windows(data, thresholds)
+        extras = self._parse_extras(data)
 
         return ProviderStatus(
             provider_name=self.name(),
@@ -217,6 +219,7 @@ class ClaudeProvider(Provider):
             cached=False,
             cache_age_seconds=0,
             windows=windows,
+            extras=extras,
         )
 
     def _parse_windows(
@@ -229,6 +232,8 @@ class ClaudeProvider(Provider):
             "five_hour": "Session (5h)",
             "seven_day": "Weekly (7d)",
             "seven_day_opus": "Weekly Opus (7d)",
+            "seven_day_sonnet": "Weekly Sonnet (7d)",
+            "seven_day_cowork": "Weekly Cowork (7d)",
         }
 
         for key, display in window_map.items():
@@ -253,7 +258,44 @@ class ClaudeProvider(Provider):
                 )
             )
 
+        # Extra usage (alpha — D-053)
+        if is_alpha_enabled(self._config):
+            extra = data.get("extra_usage")
+            if extra and extra.get("is_enabled"):
+                emit_alpha_warning()
+                utilisation = extra.get("utilization", 0.0)
+                limit_cents = extra.get("monthly_limit", 0)
+                spent_cents = extra.get("used_credits", 0.0)
+
+                status = compute_status(utilisation, thresholds)
+                windows.append(
+                    UsageWindow(
+                        name="Extra Usage",
+                        utilisation=utilisation,
+                        resets_at=None,
+                        status=status,
+                        unit="percent",
+                        raw_value=spent_cents / 100.0,
+                        raw_limit=limit_cents / 100.0,
+                    )
+                )
+
         return windows
+
+    def _parse_extras(self, data: dict) -> dict:
+        """Build the extras dict from the API response."""
+        extras: dict = {}
+
+        extra = data.get("extra_usage")
+        if extra is None:
+            extras["extra_usage_enabled"] = None
+        else:
+            extras["extra_usage_enabled"] = extra.get("is_enabled", False)
+            if extra.get("is_enabled") and is_alpha_enabled(self._config):
+                extras["extra_usage_spent"] = extra.get("used_credits", 0.0) / 100.0
+                extras["extra_usage_limit"] = extra.get("monthly_limit", 0) / 100.0
+
+        return extras
 
     def auth_instructions(self) -> str:
         return (

--- a/src/llm_monitor/providers/ollama.py
+++ b/src/llm_monitor/providers/ollama.py
@@ -10,14 +10,13 @@ See SPEC.md Section 3.4 for endpoint mapping and design rationale.
 from __future__ import annotations
 
 import os
-import sys
 from datetime import datetime, timezone
 from typing import Optional
 from urllib.parse import urlparse
 
 import httpx
 
-from llm_monitor.config import is_alpha_enabled
+from llm_monitor.config import emit_alpha_warning, is_alpha_enabled
 from llm_monitor.models import (
     CredentialError,
     ProviderStatus,
@@ -30,21 +29,6 @@ from llm_monitor.providers.base import Provider
 from llm_monitor.security import is_container_mode, run_key_command
 
 CLOUD_API_BASE = "https://ollama.com"
-
-# Module-level flag: emit the alpha warning at most once per process
-_alpha_warning_emitted = False
-
-
-def _emit_alpha_warning() -> None:
-    """Print one-time alpha feature warning to stderr."""
-    global _alpha_warning_emitted
-    if not _alpha_warning_emitted:
-        print(
-            "Warning: Alpha features are enabled. Some data sources are "
-            "unstable and may break between releases.",
-            file=sys.stderr,
-        )
-        _alpha_warning_emitted = True
 
 
 @register_provider
@@ -185,7 +169,7 @@ class OllamaProvider(Provider):
 
         # Cloud usage (alpha-gated)
         if self._cloud_enabled and is_alpha_enabled(self._config):
-            _emit_alpha_warning()
+            emit_alpha_warning()
             cloud_data = await self._fetch_cloud_usage(client, windows, errors)
             if cloud_data:
                 extras["cloud"] = cloud_data

--- a/tests/fixtures/claude_usage_response.json
+++ b/tests/fixtures/claude_usage_response.json
@@ -11,6 +11,17 @@
     "utilization": 12.0,
     "resets_at": "2026-04-08T00:00:00+00:00"
   },
+  "seven_day_sonnet": {
+    "utilization": 5.0,
+    "resets_at": "2026-04-08T00:00:00+00:00"
+  },
   "seven_day_oauth_apps": null,
-  "iguana_necktie": null
+  "seven_day_cowork": null,
+  "iguana_necktie": null,
+  "extra_usage": {
+    "is_enabled": true,
+    "monthly_limit": 10000,
+    "used_credits": 4250.0,
+    "utilization": 42.5
+  }
 }

--- a/tests/providers/test_claude.py
+++ b/tests/providers/test_claude.py
@@ -49,11 +49,18 @@ def _usage_response() -> dict:
     )
 
 
-def _make_provider(tmp_path: Path, creds: dict | None = None) -> ClaudeProvider:
+def _make_provider(
+    tmp_path: Path,
+    creds: dict | None = None,
+    alpha: bool = False,
+) -> ClaudeProvider:
     """Create a ClaudeProvider pointing at tmp_path credentials."""
     creds_path = tmp_path / ".credentials.json"
     _write_credentials(creds_path, creds)
     config = {
+        "general": {
+            "enable_alpha_features": alpha,
+        },
         "providers": {
             "claude": {
                 "credentials_path": str(creds_path),
@@ -111,8 +118,8 @@ class TestCredentialReading:
 class TestFetchUsage:
     @respx.mock
     @pytest.mark.asyncio
-    async def test_successful_response_three_windows(self, tmp_path):
-        """200 with full response produces 3 UsageWindow objects."""
+    async def test_successful_response_windows(self, tmp_path):
+        """200 with full response produces expected UsageWindow objects."""
         provider = _make_provider(tmp_path)
 
         route = respx.get("https://api.anthropic.com/api/oauth/usage").respond(
@@ -125,16 +132,18 @@ class TestFetchUsage:
         assert route.called
         assert isinstance(status, ProviderStatus)
         assert len(status.errors) == 0
-        assert len(status.windows) == 3
         names = {w.name for w in status.windows}
         assert "Session (5h)" in names
         assert "Weekly (7d)" in names
         assert "Weekly Opus (7d)" in names
+        assert "Weekly Sonnet (7d)" in names
+        # Extra Usage not present without alpha flag
+        assert "Extra Usage" not in names
 
     @respx.mock
     @pytest.mark.asyncio
-    async def test_null_opus_two_windows(self, tmp_path):
-        """When seven_day_opus is null, only 2 windows are returned."""
+    async def test_null_opus_skipped(self, tmp_path):
+        """When seven_day_opus is null, that window is not returned."""
         provider = _make_provider(tmp_path)
 
         response_data = _usage_response()
@@ -147,9 +156,11 @@ class TestFetchUsage:
         async with httpx.AsyncClient() as client:
             status = await provider.fetch_usage(client)
 
-        assert len(status.windows) == 2
         names = {w.name for w in status.windows}
         assert "Weekly Opus (7d)" not in names
+        # Other windows still present
+        assert "Session (5h)" in names
+        assert "Weekly (7d)" in names
 
     @pytest.mark.asyncio
     async def test_expired_token_no_http_call(self, tmp_path):
@@ -220,7 +231,7 @@ class TestFetchUsage:
 
         assert call_count == 2
         assert len(status.errors) == 0
-        assert len(status.windows) == 3
+        assert len(status.windows) >= 3
 
     @respx.mock
     @pytest.mark.asyncio
@@ -286,3 +297,246 @@ class TestMetadata:
         config = {"providers": {"claude": {}}}
         p = ClaudeProvider(config)
         assert "api.anthropic.com" in p.allowed_hosts
+
+
+# ---------------------------------------------------------------------------
+# seven_day_sonnet window
+# ---------------------------------------------------------------------------
+
+
+class TestSonnetWindow:
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_sonnet_window_parsed(self, tmp_path):
+        """seven_day_sonnet is mapped to Weekly Sonnet (7d) window."""
+        provider = _make_provider(tmp_path)
+
+        respx.get("https://api.anthropic.com/api/oauth/usage").respond(
+            200, json=_usage_response()
+        )
+
+        async with httpx.AsyncClient() as client:
+            status = await provider.fetch_usage(client)
+
+        sonnet = next(
+            (w for w in status.windows if w.name == "Weekly Sonnet (7d)"), None
+        )
+        assert sonnet is not None
+        assert sonnet.utilisation == 5.0
+        assert sonnet.unit == "percent"
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_null_sonnet_skipped(self, tmp_path):
+        """When seven_day_sonnet is null, no Sonnet window is returned."""
+        provider = _make_provider(tmp_path)
+
+        data = _usage_response()
+        data["seven_day_sonnet"] = None
+        respx.get("https://api.anthropic.com/api/oauth/usage").respond(
+            200, json=data
+        )
+
+        async with httpx.AsyncClient() as client:
+            status = await provider.fetch_usage(client)
+
+        names = {w.name for w in status.windows}
+        assert "Weekly Sonnet (7d)" not in names
+
+
+# ---------------------------------------------------------------------------
+# Extra usage (alpha)
+# ---------------------------------------------------------------------------
+
+
+class TestExtraUsage:
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_extra_usage_with_alpha(self, tmp_path, monkeypatch):
+        """Extra Usage window appears when alpha enabled and extra_usage present."""
+        import llm_monitor.config as config_mod
+        monkeypatch.setattr(config_mod, "_alpha_warning_emitted", False)
+
+        provider = _make_provider(tmp_path, alpha=True)
+
+        respx.get("https://api.anthropic.com/api/oauth/usage").respond(
+            200, json=_usage_response()
+        )
+
+        async with httpx.AsyncClient() as client:
+            status = await provider.fetch_usage(client)
+
+        extra = next(
+            (w for w in status.windows if w.name == "Extra Usage"), None
+        )
+        assert extra is not None
+        assert extra.utilisation == 42.5
+        assert extra.unit == "percent"
+        # 4250 cents / 100 = $42.50
+        assert extra.raw_value == pytest.approx(42.50)
+        # 10000 cents / 100 = $100.00
+        assert extra.raw_limit == pytest.approx(100.00)
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_extra_usage_hidden_without_alpha(self, tmp_path):
+        """Extra Usage window NOT present when alpha disabled."""
+        provider = _make_provider(tmp_path, alpha=False)
+
+        respx.get("https://api.anthropic.com/api/oauth/usage").respond(
+            200, json=_usage_response()
+        )
+
+        async with httpx.AsyncClient() as client:
+            status = await provider.fetch_usage(client)
+
+        names = {w.name for w in status.windows}
+        assert "Extra Usage" not in names
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_extra_usage_disabled_on_account(self, tmp_path):
+        """No Extra Usage window when is_enabled is false."""
+        provider = _make_provider(tmp_path, alpha=True)
+
+        data = _usage_response()
+        data["extra_usage"] = {
+            "is_enabled": False,
+            "monthly_limit": 0,
+            "used_credits": 0.0,
+            "utilization": 0.0,
+        }
+        respx.get("https://api.anthropic.com/api/oauth/usage").respond(
+            200, json=data
+        )
+
+        async with httpx.AsyncClient() as client:
+            status = await provider.fetch_usage(client)
+
+        names = {w.name for w in status.windows}
+        assert "Extra Usage" not in names
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_extra_usage_absent_from_response(self, tmp_path):
+        """No Extra Usage window when extra_usage field is missing entirely."""
+        provider = _make_provider(tmp_path, alpha=True)
+
+        data = _usage_response()
+        del data["extra_usage"]
+        respx.get("https://api.anthropic.com/api/oauth/usage").respond(
+            200, json=data
+        )
+
+        async with httpx.AsyncClient() as client:
+            status = await provider.fetch_usage(client)
+
+        names = {w.name for w in status.windows}
+        assert "Extra Usage" not in names
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_extra_usage_exceeds_limit(self, tmp_path, monkeypatch):
+        """used_credits can exceed monthly_limit."""
+        import llm_monitor.config as config_mod
+        monkeypatch.setattr(config_mod, "_alpha_warning_emitted", False)
+
+        provider = _make_provider(tmp_path, alpha=True)
+
+        data = _usage_response()
+        data["extra_usage"] = {
+            "is_enabled": True,
+            "monthly_limit": 10000,
+            "used_credits": 10010.0,
+            "utilization": 100.0,
+        }
+        respx.get("https://api.anthropic.com/api/oauth/usage").respond(
+            200, json=data
+        )
+
+        async with httpx.AsyncClient() as client:
+            status = await provider.fetch_usage(client)
+
+        extra = next(w for w in status.windows if w.name == "Extra Usage")
+        assert extra.raw_value == pytest.approx(100.10)
+        assert extra.raw_limit == pytest.approx(100.00)
+        assert extra.utilisation == 100.0
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_alpha_warning_emitted(self, tmp_path, monkeypatch, capfd):
+        """Alpha warning is emitted to stderr when extra usage parsed."""
+        import llm_monitor.config as config_mod
+        monkeypatch.setattr(config_mod, "_alpha_warning_emitted", False)
+
+        provider = _make_provider(tmp_path, alpha=True)
+
+        respx.get("https://api.anthropic.com/api/oauth/usage").respond(
+            200, json=_usage_response()
+        )
+
+        async with httpx.AsyncClient() as client:
+            await provider.fetch_usage(client)
+
+        captured = capfd.readouterr()
+        assert "alpha features are enabled" in captured.err.lower()
+
+
+# ---------------------------------------------------------------------------
+# Extras dict
+# ---------------------------------------------------------------------------
+
+
+class TestExtras:
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_extras_with_extra_usage_alpha(self, tmp_path, monkeypatch):
+        """Extras dict includes spend/limit when alpha enabled."""
+        import llm_monitor.config as config_mod
+        monkeypatch.setattr(config_mod, "_alpha_warning_emitted", False)
+
+        provider = _make_provider(tmp_path, alpha=True)
+
+        respx.get("https://api.anthropic.com/api/oauth/usage").respond(
+            200, json=_usage_response()
+        )
+
+        async with httpx.AsyncClient() as client:
+            status = await provider.fetch_usage(client)
+
+        assert status.extras["extra_usage_enabled"] is True
+        assert status.extras["extra_usage_spent"] == pytest.approx(42.50)
+        assert status.extras["extra_usage_limit"] == pytest.approx(100.00)
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_extras_without_alpha(self, tmp_path):
+        """Extras shows enabled status but no spend/limit without alpha."""
+        provider = _make_provider(tmp_path, alpha=False)
+
+        respx.get("https://api.anthropic.com/api/oauth/usage").respond(
+            200, json=_usage_response()
+        )
+
+        async with httpx.AsyncClient() as client:
+            status = await provider.fetch_usage(client)
+
+        assert status.extras["extra_usage_enabled"] is True
+        assert "extra_usage_spent" not in status.extras
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_extras_extra_usage_null(self, tmp_path):
+        """Extras shows null when extra_usage absent from response."""
+        provider = _make_provider(tmp_path)
+
+        data = _usage_response()
+        del data["extra_usage"]
+        respx.get("https://api.anthropic.com/api/oauth/usage").respond(
+            200, json=data
+        )
+
+        async with httpx.AsyncClient() as client:
+            status = await provider.fetch_usage(client)
+
+        assert status.extras["extra_usage_enabled"] is None

--- a/tests/providers/test_ollama_cloud.py
+++ b/tests/providers/test_ollama_cloud.py
@@ -119,8 +119,8 @@ class TestAlphaGating:
     @pytest.mark.asyncio
     async def test_alpha_warning_emitted(self, monkeypatch, capfd):
         """Alpha feature warning is printed to stderr."""
-        import llm_monitor.providers.ollama as ollama_mod
-        monkeypatch.setattr(ollama_mod, "_alpha_warning_emitted", False)
+        import llm_monitor.config as config_mod
+        monkeypatch.setattr(config_mod, "_alpha_warning_emitted", False)
 
         provider = _make_cloud_provider(monkeypatch)
         _mock_local_host()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -226,7 +226,7 @@ class TestDefaultMode:
         result = runner.invoke(cli, ["--provider", "claude", "--fresh"])
         data = json.loads(result.stdout)
         windows = data["providers"][0]["windows"]
-        assert len(windows) == 3
+        assert len(windows) >= 3
         names = {w["name"] for w in windows}
         assert "Session (5h)" in names
 
@@ -496,7 +496,7 @@ class TestFetchAll:
         assert len(statuses) == 1
         assert statuses[0].provider_name == "claude"
         assert len(statuses[0].errors) == 0
-        assert len(statuses[0].windows) == 3
+        assert len(statuses[0].windows) >= 3
 
     @respx.mock
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- **Extra usage spend** (alpha) — parses `extra_usage` from existing `/api/oauth/usage` response to show dollar spend beyond subscription cap, gated behind `enable_alpha_features`
- **Weekly Sonnet (7d)** window — new per-model utilisation window discovered in current API response
- **`credits` unit** in formatters — displays as `$X.XX` with no currency qualifier (values are in user's billing currency, not necessarily USD)
- **Shared alpha warning** — `emit_alpha_warning()` extracted to `config.py` for use by both Claude and Ollama providers
- **SPEC updates** — OQ-001, OQ-002, OQ-004, OQ-008 closed with research findings; Section 3.1 updated with extra usage field documentation

Closes #19

## Test plan

- [x] All 469 existing + new tests pass (`uv run pytest --ignore=tests/test_daemon.py`)
- [x] Manual test with `enable_alpha_features = true` — verify Extra Usage window appears in `--now` output
- [x] Manual test without alpha flag — verify Extra Usage window is absent
- [x] Verify Weekly Sonnet (7d) window appears when API returns `seven_day_sonnet`
- [x] Verify alpha warning printed to stderr on first invocation

🤖 Generated with [Claude Code](https://claude.com/claude-code)