### PR TITLE
fix: correct Docker env var names and build from source

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,3 @@
-.git
 .github
 __pycache__
 *.egg-info

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,17 @@
-FROM python:3.12-slim
+FROM python:3.12-slim AS builder
 
-RUN pip install --no-cache-dir clawmeter
+RUN apt-get update && apt-get install -y --no-install-recommends git && rm -rf /var/lib/apt/lists/*
+COPY . /tmp/build
+RUN pip install --no-cache-dir build && python -m build --wheel /tmp/build -o /tmp/dist
+
+FROM python:3.12-slim
 
 # Create non-root user
 RUN useradd --create-home --shell /bin/bash monitor
+
+COPY --from=builder /tmp/dist/*.whl /tmp/
+RUN pip install --no-cache-dir /tmp/*.whl && rm -f /tmp/*.whl
+
 USER monitor
 
 # Default data directory

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,8 +10,8 @@ services:
       - ${HOME}/.claude/.credentials.json:/home/monitor/.claude/.credentials.json:ro
     environment:
       # Cloud provider API keys (alternative to keyring)
-      - OPENAI_API_KEY=${OPENAI_API_KEY}
-      - XAI_API_KEY=${XAI_API_KEY}
+      - OPENAI_ADMIN_KEY=${OPENAI_ADMIN_KEY}
+      - XAI_MANAGEMENT_KEY=${XAI_MANAGEMENT_KEY}
       # Override poll interval (optional)
       # - CLAWMETER_POLL_INTERVAL=600
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -2479,6 +2479,28 @@ The JSON output schema (Section 4.2.3) and config file format (Section 4.6) are 
 - [x] README.md alpha features section — update Claude extra usage description from "planned" to active, add setup instructions
 - [x] CHANGELOG.md entry
 
+### v0.7.2 - Rename to clawmeter
+
+- [x] Rename Python package from `llm_monitor` to `clawmeter` (`src/llm_monitor/` → `src/clawmeter/`)
+- [x] Rename environment variables from `LLM_MONITOR_*` to `CLAWMETER_*`
+- [x] Update all internal imports, config paths, CLI entry points, Docker config
+- [x] Add migration logic for existing `llm-monitor` config/cache/data directories
+- [x] Update all documentation (README, SPEC, CHANGELOG) for new name
+
+### v0.7.3 - Docker Compose Fixes
+
+Tracked as [#24](https://github.com/danielithomas/clawmeter/issues/24).
+
+- [ ] Fix incorrect environment variable names in `docker-compose.yml` (`OPENAI_API_KEY` → `OPENAI_ADMIN_KEY`, `XAI_API_KEY` → `XAI_MANAGEMENT_KEY`)
+- [ ] Fix container build issues
+
+### v0.7.4 - PyPI Deployment
+
+Tracked as [#25](https://github.com/danielithomas/clawmeter/issues/25).
+
+- [ ] Publish `clawmeter` package to PyPI
+- [ ] Verify `uv tool install clawmeter` and `pip install clawmeter` work from PyPI
+
 ### v0.8.0 - Local System Metrics Provider
 
 - [ ] NVIDIA GPU metrics via `pynvml`


### PR DESCRIPTION
## Summary
- Fix incorrect environment variable names in `docker-compose.yml` (`OPENAI_API_KEY` → `OPENAI_ADMIN_KEY`, `XAI_API_KEY` → `XAI_MANAGEMENT_KEY`) to match what the providers actually expect
- Fix container build by switching to a multi-stage Dockerfile that builds from source (package not yet on PyPI)
- Remove `.git` from `.dockerignore` so `hatch-vcs` can resolve the version from git tags

Closes #24

## Test plan
- [x] `docker build -t clawmeter:test .` succeeds
- [x] `docker run --rm --entrypoint clawmeter clawmeter:test --help` shows CLI help
- [x] All 492 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)